### PR TITLE
Fixed framerate dependency of mech movement

### DIFF
--- a/OutOfOrbit/Assets/Scenes/SystemTests/MechMovement.unity
+++ b/OutOfOrbit/Assets/Scenes/SystemTests/MechMovement.unity
@@ -155,9 +155,9 @@ MonoBehaviour:
   mech: {fileID: 1284361892}
   rotateInput: {fileID: -1534571792233372199, guid: a844e9ae88ddd8c408b93f90668799ad, type: 3}
   thrustInput: {fileID: 5090213057515970326, guid: a844e9ae88ddd8c408b93f90668799ad, type: 3}
-  movementAcceleration: 50
-  maxVelocity: 100
-  rotationSpeed: 15
+  movementAcceleration: 70
+  maxVelocity: 210
+  rotationSpeed: 25
   velocity: {x: 0, y: 0, z: 0}
   angularVelocity: {x: 0, y: 0, z: 0}
   rotateValue: {x: 0, y: 0}

--- a/OutOfOrbit/Assets/Scripts/Movement and Interaction/MechMovementController.cs
+++ b/OutOfOrbit/Assets/Scripts/Movement and Interaction/MechMovementController.cs
@@ -48,7 +48,7 @@ public class MechMovementController : MonoBehaviour
         mech.maxLinearVelocity = maxVelocity;
     }
 
-    private void Update()
+    private void FixedUpdate()
     {
         // Debug.Log($"Rotation value: {rotate.ReadValue<Vector2>()}");
         // Debug.Log($"Thrust value:   {thrust.ReadValue<float>()}");


### PR DESCRIPTION
Modified MechMovement script to run move & rotate in FixedUpdate in order to fix the framerate dependency
- Before, those functions were run in Update
- Also updated acceleration, maxVelocity and rotationSpeed values in MechMovement scene to make up for this change, as FixedUpdate() is called less than Update()