### PR TITLE
Implemented automatic selection of default player depending on DisplayCount

### DIFF
--- a/OutOfOrbit/Assets/Scripts/Settings.cs
+++ b/OutOfOrbit/Assets/Scripts/Settings.cs
@@ -6,5 +6,22 @@ public class Settings : MonoBehaviour
 {
     //# Debug Flags 
     public static bool showOwnedNetworkPlayer = true;
-    public static PlayerType defaultXRPlayer = PlayerType.CAVE;
+    private static PlayerType? m_defaultXRPlayer;   //< Set this value manually in this script to overwrite automatic player type selection.
+    public static PlayerType defaultXRPlayer
+    {
+        set
+        {
+            if (m_defaultXRPlayer.HasValue)
+                Debug.LogWarning($"Default player has been set to {m_defaultXRPlayer.Value} manually in Settings. If you wish to allow for automatic selection of the default player, please remove the value of m_defaultXRPlayer within the script.");
+            else
+                m_defaultXRPlayer = value;
+        }
+        get
+        {
+            if (!m_defaultXRPlayer.HasValue)
+                Debug.LogWarning($"Default player has not been set yet, returning default value ({m_defaultXRPlayer.GetValueOrDefault()}).");
+            return m_defaultXRPlayer.GetValueOrDefault();
+        }
+    }
+    public bool isOverwritingDefaultXRPlayer { get { return m_defaultXRPlayer.HasValue; } }
 }

--- a/OutOfOrbit/Assets/Scripts/XRPlayer/PlayerHandler.cs
+++ b/OutOfOrbit/Assets/Scripts/XRPlayer/PlayerHandler.cs
@@ -14,11 +14,22 @@ public class PlayerHandler : MonoBehaviour
         else
             DestroyImmediate(this);
 
+        DisplayCountChecker();
         SetCurrentPlayerBasedOnSettings();
     }
 
     private void SetCurrentPlayerBasedOnSettings()
     {
         XRPlayer.SetAsCurrent(Settings.defaultXRPlayer);
+    }
+
+    private void DisplayCountChecker()
+    {
+        int displayCount = Display.displays.Length;
+        Debug.Log($"{displayCount} Display{(displayCount > 1 ? "s" : "")} connected: Trying to set default player to {(displayCount >= 7 ? "CAVE" : "HMD")}.");
+        if (displayCount >= 7)
+            Settings.defaultXRPlayer = PlayerType.CAVE;
+        else
+            Settings.defaultXRPlayer = PlayerType.HMD;
     }
 }


### PR DESCRIPTION
- Depending on the amount of displays connected to the device / computer, this system chooses CAVE or HMD as the default player type, unless manually overwritten by assigning either value in the Settings script